### PR TITLE
Update logo reference comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ Você precisará de dois terminais abertos para rodar o backend e o frontend sim
 ## 🎨 Design e Estilo
 * O frontend utiliza um tema escuro inspirado na referência visual fornecida.
 * As cores institucionais da PGE-MS (Azul `#294964`, Laranja `#F58634`, Ciano `#51A8B1`) são usadas como acentos.
-* O logo da PGE-MS (versão branca) é exibido no header.
+* O logo da PGE-MS (versão branca) é exibido no header. Certifique-se de que o arquivo
+  `logo-pge-branco.png` esteja presente em `frontend/detran/public/` ou ajuste o
+  caminho definido no componente `Layout.jsx`.
 * Fontes: Inter (corpo) e Poppins (títulos).
 
 ## 🔮 Próximos Passos / Melhorias Futuras (Sugestões)

--- a/frontend/detran/src/components/Layout.jsx
+++ b/frontend/detran/src/components/Layout.jsx
@@ -1,9 +1,9 @@
 // src/components/Layout.jsx
 import React from 'react';
 
-// Assumindo que 'logo-pge-branco.png' está na pasta 'public' do seu projeto Vite.
-// Se você moveu para 'src/assets', o import seria: import logoPgeUrl from '../assets/logo-pge-branco.png';
-const logoPgeUrl = '/logo-pge-branco.png'; // Caminho relativo à pasta 'public'
+// Ajuste o caminho conforme a localização do arquivo de logo.
+// Por padrão espera-se que 'logo-pge-branco.png' esteja em 'frontend/detran/public/'.
+const logoPgeUrl = '/logo-pge-branco.png';
 
 const Layout = ({ children, onNewAnalysis }) => {
   return (


### PR DESCRIPTION
## Summary
- clarify where the logo asset should be placed in `Layout.jsx`
- note logo placement requirement in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f44d2e7a08331add48b7b2b4ea63c