### PR TITLE
Add Vite API base URL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ O projeto é dividido em duas pastas principais:
     # ou, se você usa Yarn:
     # yarn install
     ```
+3.  **Configure a URL do backend para o Vite:**
+    Copie o arquivo `.env.example` para `.env` dentro da pasta `frontend` e ajuste o valor de `VITE_API_BASE_URL` caso o endereço do backend seja diferente de `http://localhost:5000`.
 
 ## ▶️ Executando a Aplicação
 
@@ -94,6 +96,7 @@ Você precisará de dois terminais abertos para rodar o backend e o frontend sim
         python contestacao.py
         ```
     * O backend estará rodando (por padrão) em `http://localhost:5000`.
+      Defina essa URL em `VITE_API_BASE_URL` caso utilize outro endereço.
 
 2.  **Inicie o Servidor Frontend (React/Vite):**
     * No outro terminal, na pasta `frontend/`:

--- a/frontend/detran/.env.example
+++ b/frontend/detran/.env.example
@@ -1,0 +1,3 @@
+# Exemplo de configuração para o frontend (Vite)
+# URL base do backend
+VITE_API_BASE_URL=http://localhost:5000

--- a/frontend/detran/src/components/ResultScreen.jsx
+++ b/frontend/detran/src/components/ResultScreen.jsx
@@ -1,6 +1,9 @@
 // src/components/ResultScreen.jsx
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+
+// URL base da API definida via variável de ambiente do Vite
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
 import { Markup } from 'interweave'; // Para renderizar HTML de forma segura
 
 // FUNÇÃO LOCAL PARA ESCAPAR HTML BÁSICO
@@ -98,7 +101,7 @@ const ResultScreen = ({
       params.append('action', 'ajustar_minuta');
       params.append('instrucoes_ajuste', ajusteInstrucoes);
 
-      const response = await axios.post('http://localhost:5000/', params); 
+      const response = await axios.post(`${API_BASE_URL}/`, params);
       
       onMinutaAdjusted(response.data); 
       if(response.data.success) {

--- a/frontend/detran/src/components/UploadScreen.jsx
+++ b/frontend/detran/src/components/UploadScreen.jsx
@@ -3,6 +3,9 @@ import React, { useState, useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import axios from 'axios'; // Para chamadas HTTP
 
+// URL base da API definida via variável de ambiente do Vite
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+
 // Ícone de Upload (SVG Tailwind-friendly)
 const UploadIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="mx-auto h-16 w-16 text-gray-500 group-hover:text-pge-ciano transition-colors">
@@ -61,7 +64,7 @@ const UploadScreen = ({ onMinutaResponse, setIsLoading, isLoading, setError }) =
     formData.append('action', 'upload_pdfs'); // O backend espera esta ação
 
     try {
-      const response = await axios.post('http://localhost:5000/', formData, { 
+      const response = await axios.post(`${API_BASE_URL}/`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
       onMinutaResponse(response.data); 


### PR DESCRIPTION
## Summary
- configure axios base URL via `VITE_API_BASE_URL`
- show how to set the new variable in `.env.example`
- document the variable in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f448dfbc88331a3d0b40f27612c90