### PR TITLE
Enable credentialed CORS and axios cookie sharing

### DIFF
--- a/backend/contestacao.py
+++ b/backend/contestacao.py
@@ -31,7 +31,8 @@ logger = logging.getLogger(__name__)
 
 # --- Configuração Inicial ---
 app = Flask(__name__)
-CORS(app)  # Habilita CORS para todas as rotas em desenvolvimento
+# Permite o envio de cookies de sessão para clientes frontend
+CORS(app, supports_credentials=True)
 app.secret_key = os.environ.get('FLASK_SECRET_KEY', os.urandom(32)) # Importante para assinar o cookie de ID
 
 # --- Configuração do Flask-Session (Sessões no Lado do Servidor) ---

--- a/frontend/detran/src/components/ResultScreen.jsx
+++ b/frontend/detran/src/components/ResultScreen.jsx
@@ -98,7 +98,11 @@ const ResultScreen = ({
       params.append('action', 'ajustar_minuta');
       params.append('instrucoes_ajuste', ajusteInstrucoes);
 
-      const response = await axios.post('http://localhost:5000/', params); 
+      const response = await axios.post(
+        'http://localhost:5000/',
+        params,
+        { withCredentials: true }
+      );
       
       onMinutaAdjusted(response.data); 
       if(response.data.success) {

--- a/frontend/detran/src/components/UploadScreen.jsx
+++ b/frontend/detran/src/components/UploadScreen.jsx
@@ -61,9 +61,14 @@ const UploadScreen = ({ onMinutaResponse, setIsLoading, isLoading, setError }) =
     formData.append('action', 'upload_pdfs'); // O backend espera esta ação
 
     try {
-      const response = await axios.post('http://localhost:5000/', formData, { 
-        headers: { 'Content-Type': 'multipart/form-data' },
-      });
+      const response = await axios.post(
+        'http://localhost:5000/',
+        formData,
+        {
+          headers: { 'Content-Type': 'multipart/form-data' },
+          withCredentials: true,
+        }
+      );
       onMinutaResponse(response.data); 
     } catch (err) {
       console.error("Erro no upload/geração da minuta:", err);


### PR DESCRIPTION
## Summary
- enable credentials in Flask CORS configuration
- send cookies in axios calls from UploadScreen and ResultScreen

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python backend/contestacao.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683f44884f9483318ddd8fb332f8e1d1